### PR TITLE
fix: postgresql DB 연결 문제 해결 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -65,7 +65,7 @@ services:
       - ./postgres_data:/var/lib/postgresql/data
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-airflow}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-airflow} -d ${POSTGRES_DB:-airflow}"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## 💡 개요
`docker compose up -d` 로 컨테이너를 올린 뒤, 계속해서 에러가 발생하는 것을 확인함
찾아보니, healthcheck 시에 database 이름을 명시하지 않으면 user의 이름을 database 이름으로 넣는다고 해서 이름을 명시하는 방향으로 수정하였음

* Issue Number: #2 

## 🪐 주요 변경 사항
- postgresql healthcheck 시 database 이름을 명시

## ✅ 상세 내용
- yaml 파일의 postgresql healthcheck 구문에 `-d ${POSTGRES_DB:-airflow}` 추가

## 🔔 참고 사항
- X