### PR TITLE
feat: PostgreSQL mart.city 테이블 초기화 자동화

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,6 +62,7 @@ services:
       - "5432:5432"
     # 데이터 영구 저장을 위한 volume 연결
     volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
       - ./postgres_data:/var/lib/postgresql/data
     restart: always
     healthcheck:

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,38 @@
+-- init.sql
+
+-- mart schema 생성
+CREATE SCHEMA IF NOT EXISTS mart;
+
+-- city table 생성
+CREATE TABLE IF NOT EXISTS mart.city (
+    id SERIAL NOT NULL PRIMARY KEY,
+    openweather_city_id INTEGER,
+    name VARCHAR(100),
+    country CHAR(3),
+    latitude NUMERIC(10,7),
+    longitude NUMERIC(10,7),
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 데이터 삽입
+INSERT INTO mart.city (openweather_city_id, name, country, latitude, longitude) VALUES
+(2968815, 'paris', 'FRA', 48.8566, 2.3522),
+(6545095, 'madrid', 'ESP', 40.4168, -3.7038),
+(1857654, 'tokyo', 'JPN', 35.6769, 139.7639),
+(6545158, 'rome', 'ITA', 41.9028, 12.4964),
+(3173435, 'milan', 'ITA', 45.4642, 9.19),
+(5128581, 'newyork', 'USA', 40.7128, -74.006),
+(2759794, 'amsterdam', 'NLD', 52.3676, 4.9041),
+(3119123, 'barcelona', 'ESP', 41.3829, 2.1774),
+(1880252, 'singapore', 'SGP', 1.2899, 103.8519),
+(1835848, 'seoul', 'KOR', 37.5665, 126.978),
+(1608132, 'bangkok', 'THA', 13.7525, 100.4935),
+(8223932, 'hongkong', 'HKG', 22.2793, 114.1628),
+(2643743, 'london', 'GBR', 51.5074, -0.1278),
+(1821274, 'macao', 'MAC', 22.1987, 113.5439),
+(738354, 'istanbul', 'TUR', 41.0091, 28.97),
+(290845, 'dubai', 'ARE', 25.2653, 55.2925),
+(104515, 'mecca', 'SAU', 21.4208, 39.8269),
+(323777, 'antalya', 'TUR', 36.8969, 30.7133),
+(1733046, 'kualalumpur', 'MYS', 3.139, 101.6869),
+(1838519, 'busan', 'KOR', 35.1796, 129.0756);

--- a/init.sql
+++ b/init.sql
@@ -6,11 +6,11 @@ CREATE SCHEMA IF NOT EXISTS mart;
 -- city table 생성
 CREATE TABLE IF NOT EXISTS mart.city (
     id SERIAL NOT NULL PRIMARY KEY,
-    openweather_city_id INTEGER,
-    name VARCHAR(100),
-    country CHAR(3),
-    latitude NUMERIC(10,7),
-    longitude NUMERIC(10,7),
+    openweather_city_id INTEGER NOT NULL UNIQUE,
+    name VARCHAR(100) NOT NULL,
+    country CHAR(3) NOT NULL,
+    latitude NUMERIC(10,7) NOT NULL,
+    longitude NUMERIC(10,7) NOT NULL,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
 


### PR DESCRIPTION
## 💡 개요
PostgreSQL의 mart 스키마와 city 테이블을 초기화하고 데이터를 insert하는 과정을 자동화하였다

* Issue Number: #8 

## 🪐 주요 변경 사항
- init.sql 작성
- docker 볼륨과 init.sql 파일 마운트

## ✅ 상세 내용
- schema와 table create 구문, 20개 도시 데이터를 수집하여 init.sql의 insert 구문을 작성함

## 🔔 참고 사항
- ISO 3166 country code
- gemini로 좌표를 일차적으로 수집 후 current weather api 호출 시 확인할 수 있는 city name과 일치하지 않는 경우, openweatehr geo api를 사용해 도시명으로 조회한 좌표로 교체해주었음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 데이터베이스 초기화 기능이 추가되어 컨테이너 시작 시 자동으로 도시 정보 테이블이 생성되고 초기 데이터가 로드됩니다.

* **작업**
  * 20개의 전 세계 도시 데이터를 포함한 데이터베이스 스키마가 자동으로 설정되며, 향후 데이터 초기화 프로세스가 간편해집니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->